### PR TITLE
Fix V3083 warnings from PVS-Studio Static Analyzer

### DIFF
--- a/lib/TweetLib.Audio/Impl/SoundPlayerImplFallback.cs
+++ b/lib/TweetLib.Audio/Impl/SoundPlayerImplFallback.cs
@@ -45,7 +45,7 @@ namespace TweetLib.Audio.Impl{
         private void OnNotificationSoundError(string message){
             if (!ignorePlaybackError && PlaybackError != null){
                 PlaybackErrorEventArgs args = new PlaybackErrorEventArgs(message);
-                PlaybackError(this, args);
+                PlaybackError?.Invoke(this, args);
                 ignorePlaybackError = args.Ignore;
             }
         }

--- a/lib/TweetLib.Audio/Impl/SoundPlayerImplFallback.cs
+++ b/lib/TweetLib.Audio/Impl/SoundPlayerImplFallback.cs
@@ -43,7 +43,7 @@ namespace TweetLib.Audio.Impl{
         }
 
         private void OnNotificationSoundError(string message){
-            if (!ignorePlaybackError && PlaybackError != null){
+            if (!ignorePlaybackError){
                 PlaybackErrorEventArgs args = new PlaybackErrorEventArgs(message);
                 PlaybackError?.Invoke(this, args);
                 ignorePlaybackError = args.Ignore;

--- a/lib/TweetLib.Audio/Impl/SoundPlayerImplWMP.cs
+++ b/lib/TweetLib.Audio/Impl/SoundPlayerImplWMP.cs
@@ -102,7 +102,7 @@ namespace TweetLib.Audio.Impl{
             if (wasTryingToPlay){
                 wasTryingToPlay = false;
 
-                if (!ignorePlaybackError && PlaybackError != null){
+                if (!ignorePlaybackError){
                     PlaybackErrorEventArgs args = new PlaybackErrorEventArgs(message);
                     PlaybackError?.Invoke(this, args);
                     ignorePlaybackError = args.Ignore;

--- a/lib/TweetLib.Audio/Impl/SoundPlayerImplWMP.cs
+++ b/lib/TweetLib.Audio/Impl/SoundPlayerImplWMP.cs
@@ -104,7 +104,7 @@ namespace TweetLib.Audio.Impl{
 
                 if (!ignorePlaybackError && PlaybackError != null){
                     PlaybackErrorEventArgs args = new PlaybackErrorEventArgs(message);
-                    PlaybackError(this, args);
+                    PlaybackError?.Invoke(this, args);
                     ignorePlaybackError = args.Ignore;
                 }
             }


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug found using PVS-Studio. Warning:

[V3083](https://www.viva64.com/en/w/v3083/) Unsafe invocation of event 'PlaybackError', NullReferenceException is possible. Consider assigning event to a local variable before invoking it. SoundPlayerImplFallback.cs 48
[V3083](https://www.viva64.com/en/w/v3083/) Unsafe invocation of event 'PlaybackError', NullReferenceException is possible. Consider assigning event to a local variable before invoking it. SoundPlayerImplWMP.cs 107